### PR TITLE
📜 docs: Changed README Badges back to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,6 @@
-<a href="https://github.com/TJC-Tools/TJC.AssemblyExtensions/tags">
-  <img alt="GitHub Tag" src="https://img.shields.io/github/v/tag/TJC-Tools/TJC.AssemblyExtensions?style=for-the-badge&logo=tag&logoColor=white&labelColor=24292f&color=blue" />
-</a>
+![GitHub Tag](https://img.shields.io/github/v/tag/TJC-Tools/TJC.AssemblyExtensions) [![GitHub Release](https://img.shields.io/github/v/release/TJC-Tools/TJC.AssemblyExtensions)](https://github.com/TJC-Tools/TJC.AssemblyExtensions/releases/latest) [![NuGet Version](https://img.shields.io/nuget/v/TJC.AssemblyExtensions)](https://www.nuget.org/packages/TJC.AssemblyExtensions)
 
-<a href="https://github.com/TJC-Tools/TJC.AssemblyExtensions/releases/latest">
-  <img alt="GitHub Release" src="https://img.shields.io/github/v/release/TJC-Tools/TJC.AssemblyExtensions?style=for-the-badge&logo=starship&logoColor=D9E0EE&labelColor=302D41&&color=green&include_prerelease&sort=semver" />
-</a>
-
-<a href="https://www.nuget.org/packages/TJC.AssemblyExtensions">
-  <img alt="NuGet Version" src="https://img.shields.io/nuget/v/TJC.AssemblyExtensions?style=for-the-badge&logo=nuget&logoColor=white&labelColor=004880&color=blue" />
-</a>
-
-<br/>
-
-<a href="https://www.nuget.org/packages/TJC.AssemblyExtensions">
-  <img alt="NuGet Downloads" src="https://img.shields.io/nuget/dt/TJC.AssemblyExtensions?style=for-the-badge&logo=nuget&logoColor=white&labelColor=004880&color=yellow" />
-</a>
-
-<a href="https://github.com/TJC-Tools/TJC.AssemblyExtensions">
-  <img alt="Repository Size" src="https://img.shields.io/github/repo-size/TJC-Tools/TJC.AssemblyExtensions?style=for-the-badge&logo=files&logoColor=white&labelColor=24292f&color=orange" />
-</a>
-
-<br/>
-
-<a href="https://github.com/TJC-Tools/TJC.AssemblyExtensions">
-  <img alt="Last commit" src="https://img.shields.io/github/last-commit/TJC-Tools/TJC.AssemblyExtensions?style=for-the-badge&logo=git&logoColor=D9E0EE&labelColor=302D41&color=mediumpurple"/>
-</a>
-
-<a href="LICENSE">
-  <img alt="License" src="https://img.shields.io/github/license/TJC-Tools/TJC.AssemblyExtensions.svg?style=for-the-badge&logo=balance-scale&logoColor=white&labelColor=333333&color=blueviolet" />
-</a>
+[![NuGet Downloads](https://img.shields.io/nuget/dt/TJC.AssemblyExtensions)](https://www.nuget.org/packages/TJC.AssemblyExtensions) ![Size](https://img.shields.io/github/repo-size/TJC-Tools/TJC.AssemblyExtensions) [![License](https://img.shields.io/github/license/TJC-Tools/TJC.AssemblyExtensions.svg)](LICENSE)
 
 ## T? [Assembly](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly?view=net-8.0).[GetAssemblyAttribute](./TJC.AssemblyExtensions/Attributes/AttributeExtensions.cs)()
 - Used to get attributes of an assembly.


### PR DESCRIPTION
Since HTML Badges don't render on nuget